### PR TITLE
Rails does not start without symlinking  shared/application.yml to current/application.yml

### DIFF
--- a/definitions/custom_env_template.rb
+++ b/definitions/custom_env_template.rb
@@ -17,5 +17,9 @@ define :custom_env_template do
 
     only_if { File.exists?("#{params[:deploy][:deploy_to]}/shared/config") }
   end
-  
+
+  link "#{params[:deploy][:deploy_to]}/shared/config/application.yml" do
+    to "#{params[:deploy][:deploy_to]}/current/config/application.yml"
+  end
+
 end


### PR DESCRIPTION
I don´t know if it´s the best place to put the link resource. But because I don´t want to mess with the opsworks deploy, I figured this would be OK. 

Can we use deploy hooks to write another deploy recipe using the symlink attribute from the deploy resource? 
