### PR TITLE
Refactors to use the restart command attribute from opsworks

### DIFF
--- a/recipes/restart_command.rb
+++ b/recipes/restart_command.rb
@@ -2,7 +2,7 @@ node[:deploy].each do |application, deploy|
 
   execute "restart Rails app #{application} for custom env" do
     cwd deploy[:current_path]
-    command "#{deploy[:deploy_to]}/shared/scripts/unicorn restart"
+    command node[:opsworks][:rails_stack][:restart_command]
     user deploy[:user]
 
     action :nothing


### PR DESCRIPTION
This will allow usage in other contexts (Passenger, etc.) as new
ones are added.

Just tested it this morning against passenger and seems to be working fine.
