### PR TITLE
include OpsWorks App environment variables in application.yml

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,6 +1,2 @@
-if node[:opsworks][:instance][:layers].include?('rails-app')
-
-  include_recipe "opsworks_custom_env::restart_command"
-  include_recipe "opsworks_custom_env::write_config"
-
-end
+include_recipe "opsworks_custom_env::restart_command"
+include_recipe "opsworks_custom_env::write_config"

--- a/recipes/restart_command.rb
+++ b/recipes/restart_command.rb
@@ -4,7 +4,7 @@ node[:deploy].each do |application, deploy|
     cwd deploy[:current_path]
     if node[:opsworks][:rails_stack][:name].eql? "apache_passenger"
       command "touch #{deploy[:deploy_to]}/current/tmp/restart.txt"
-    elsif node[:opsworks][:rails_stack][:recipe].eql? "nginx_unicorn"
+    elsif node[:opsworks][:rails_stack][:name].eql? "nginx_unicorn"
       command "#{deploy[:deploy_to]}/shared/scripts/unicorn clean-restart"
     end
     user deploy[:user]

--- a/recipes/write_config.rb
+++ b/recipes/write_config.rb
@@ -6,7 +6,7 @@ node[:deploy].each do |application, deploy|
   custom_env_template do
     application application
     deploy deploy
-    env node[:custom_env][application]
+    env (node[:custom_env][application] || {}).merge(deploy[:environment_variables])
   end
   
 end


### PR DESCRIPTION
Environment variables [can now be set for an Application in the AWS console](https://blogs.aws.amazon.com/application-management/post/Tx2G95J53SKI2E0/AWS-OpsWorks-supports-application-environment-variables). But they're only made available to application worker processes, not to other commands (rake tasks or rails console via remote login), or even to rake tasks that run during setup and configure events.

The app-level variables are by nature more granular, and can be protected values, restricted via IAM etc, so there are advantages to using them. Bummer that they're not available outside worker processes, but combining with opsworks_custom_env can fix that too. 

This PR merges those app ENV variables with the stack JSON defined variables into application.yml, so they too may be leveraged by figaro via application.yml. You can mix usage of stack (JSON) and app environment variables.

also, I added a fix for detection of `nginx_unicorn` stacks (http://docs.aws.amazon.com/opsworks/latest/userguide/attributes-json-opsworks-rails-stack.html)
