### PR TITLE
write_config can be executed on any rails app, not limited to rails-app layer

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,6 +1,2 @@
-if node[:opsworks][:instance][:layers].include?('rails-app')
-
-  include_recipe "opsworks_custom_env::restart_command"
-  include_recipe "opsworks_custom_env::write_config"
-
-end
+include_recipe "opsworks_custom_env::restart_command"
+include_recipe "opsworks_custom_env::write_config"

--- a/recipes/restart_command.rb
+++ b/recipes/restart_command.rb
@@ -1,5 +1,4 @@
 node[:deploy].each do |application, deploy|
-
   execute "restart Rails app #{application} for custom env" do
     cwd deploy[:current_path]
     if node[:opsworks][:rails_stack][:name].eql? "apache_passenger"
@@ -10,6 +9,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
 
     action :nothing
-  end
 
+    only_if { node[:opsworks][:instance][:layers].include?('rails-app') }
+  end
 end

--- a/recipes/write_config.rb
+++ b/recipes/write_config.rb
@@ -2,11 +2,15 @@
 # See https://forums.aws.amazon.com/thread.jspa?threadID=118107
 
 node[:deploy].each do |application, deploy|
-  
+  # rails apps only
+  next unless deploy[:application_type].eql?('rails')
+  # and only if custom_env JSON is present
+  next unless node[:custom_env].present? && node[:custom_env][application].present?
+
   custom_env_template do
     application application
     deploy deploy
     env node[:custom_env][application]
   end
-  
 end
+


### PR DESCRIPTION
We had to use custom_env for utility instances that weren't part of Rails app layer, but their own custom one.

This allows custom_env to be used by any 'rails' application, regardless of which layer they are in.