### PR TITLE
Dispatch by recipe name for `nginx_unicorn` stacks

### DIFF
--- a/recipes/restart_command.rb
+++ b/recipes/restart_command.rb
@@ -4,7 +4,7 @@ node[:deploy].each do |application, deploy|
     cwd deploy[:current_path]
     if node[:opsworks][:rails_stack][:name].eql? "apache_passenger"
       command "touch #{deploy[:deploy_to]}/current/tmp/restart.txt"
-    elsif node[:opsworks][:rails_stack][:recipe].eql? "nginx_unicorn"
+    elsif node[:opsworks][:rails_stack][:name].eql? "nginx_unicorn"
       command "#{deploy[:deploy_to]}/shared/scripts/unicorn clean-restart"
     end
     user deploy[:user]


### PR DESCRIPTION
The `recipe` attribute isn't set for `nginx_unicorn` stacks. The `name` attribute is set instead, just like `apache_passenger` stacks.