### PR TITLE
Modify the cookbook to allow it to be run on any layer, not just 'rails-app'

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,6 +1,2 @@
-if node[:opsworks][:instance][:layers].include?('rails-app')
-
-  include_recipe "opsworks_custom_env::restart_command"
-  include_recipe "opsworks_custom_env::write_config"
-
-end
+include_recipe "opsworks_custom_env::restart_command"
+include_recipe "opsworks_custom_env::write_config"

--- a/recipes/restart_command.rb
+++ b/recipes/restart_command.rb
@@ -1,5 +1,4 @@
 node[:deploy].each do |application, deploy|
-
   execute "restart Rails app #{application} for custom env" do
     cwd deploy[:current_path]
     if node[:opsworks][:rails_stack][:name].eql? "apache_passenger"
@@ -10,6 +9,7 @@ node[:deploy].each do |application, deploy|
     user deploy[:user]
 
     action :nothing
-  end
 
+    only_if { node[:opsworks][:instance][:layers].include?('rails-app') }
+  end
 end

--- a/recipes/write_config.rb
+++ b/recipes/write_config.rb
@@ -2,11 +2,14 @@
 # See https://forums.aws.amazon.com/thread.jspa?threadID=118107
 
 node[:deploy].each do |application, deploy|
-  
+  # rails apps only
+  next unless deploy[:application_type].eql?('rails')
+  # and only if custom_env JSON is present
+  next unless node[:custom_env].present? && node[:custom_env][application].present?
+
   custom_env_template do
     application application
     deploy deploy
     env node[:custom_env][application]
   end
-  
 end

--- a/recipes/write_config.rb
+++ b/recipes/write_config.rb
@@ -10,6 +10,6 @@ node[:deploy].each do |application, deploy|
   custom_env_template do
     application application
     deploy deploy
-    env node[:custom_env][application]
+    env node[:custom_env][application] || {}
   end
 end


### PR DESCRIPTION
It will restart the server in a rails-app layer only. And will only write
application.yml if it is a rails app that is being deployed.

Ran into this problem when created a utility instance that was running delayed jobs only and wasn't part of rails app layer. I needed to set env variables for the delayed job to work but application.yml wasn't being written because the instance wasn't part of rails-app layer.
